### PR TITLE
chore: add IPv6 example to the demo-app

### DIFF
--- a/camara-node-sdk/demo-app/views/pages/login.ejs
+++ b/camara-node-sdk/demo-app/views/pages/login.ejs
@@ -25,6 +25,7 @@
       <select name="ipport" id="ipport">
         <option value="83.58.58.57" selected>83.58.58.57:3543 (Telefónica)</option>
         <option value="109.42.3.0">109.42.3.0:4631 (Vodafone)</option>
+        <option value="2a02:9009:5:3134::1">[2a02:9009:5:3134::1]:6273 (Telefónica)</option>
       </select>
       <br/>
       <hr/>


### PR DESCRIPTION
Add IPv6 end-user identifier example.

I've tested that resolution works:

>>> whois = IPWhois ("2a02:9009:5:3134::1").lookup_whois()
>>> print(whois)
{'nir': None, 'asn_registry': 'ripencc', 'asn': '3352', 'asn_cidr': '2a02:9000::/23', 'asn_country_code': 'ES', 'asn_date': '2011-03-02', 'asn_description': 'TELEFONICA_DE_ESPANA, ES', 'query': '2a02:9009:5:3134::1', 'nets': [{'cidr': '2a02:9000::/23', 'name': 'ES-TELEFONICA-20110302', 'handle': 'ATDE1-RIPE', 'range': '2a02:9000:: - 2a02:91ff:ffff:ffff:ffff:ffff:ffff:ffff', 'description': 'ES-TELEFONICA-20110302\nTelefonica de Espana', 'country': 'ES', 'state': None, 'city': None, 'address': 'C/ Gran Via 28\n28013\nMadrid\nSPAIN', 'postal_code': None, 'emails': ['nemesys@telefonica.es'], 'created': '2011-03-02T17:17:14Z', 'updated': '2017-02-17T12:33:16Z'}], 'raw': None, 'referral': None, 'raw_referral': None}
```