### PR TITLE
chore: docker compose with host environment variables

### DIFF
--- a/.azure.env
+++ b/.azure.env
@@ -1,7 +1,0 @@
-AGGREGATOR_TELCO_ROUTER_1_HOST="https://aggregator-telco-router-1.opengateway.baikalplatform.es"
-AGGREGATOR_TELCO_ROUTER_2_HOST="https://aggregator-telco-router-2.opengateway.baikalplatform.es"
-OPERATOR_PLATFORM_AUTHSERVER_1_HOST="https://operator-platform-authserver-1.opengateway.baikalplatform.es"
-OPERATOR_PLATFORM_AUTHSERVER_2_HOST="https://operator-platform-authserver-2.opengateway.baikalplatform.es"
-DEMO_APP_HOST="https://opengateway.baikalplatform.es"
-CAMARA_API_URL="https://aggregator-telco-router-2.opengateway.baikalplatform.es/api"
-CAMARA_AUTH_URL="https://aggregator-telco-router-2.opengateway.baikalplatform.es/oauth2"

--- a/.azure.env
+++ b/.azure.env
@@ -1,0 +1,7 @@
+AGGREGATOR_TELCO_ROUTER_1_HOST="https://aggregator-telco-router-1.opengateway.baikalplatform.es"
+AGGREGATOR_TELCO_ROUTER_2_HOST="https://aggregator-telco-router-2.opengateway.baikalplatform.es"
+OPERATOR_PLATFORM_AUTHSERVER_1_HOST="https://operator-platform-authserver-1.opengateway.baikalplatform.es"
+OPERATOR_PLATFORM_AUTHSERVER_2_HOST="https://operator-platform-authserver-2.opengateway.baikalplatform.es"
+DEMO_APP_HOST="https://opengateway.baikalplatform.es"
+CAMARA_API_URL="https://aggregator-telco-router-2.opengateway.baikalplatform.es/api"
+CAMARA_AUTH_URL="https://aggregator-telco-router-2.opengateway.baikalplatform.es/oauth2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,7 @@ services:
     environment:
       PORT: 3311
       TELCO_FINDER_HOST: "http://aggregator-telco-finder-1:2211"
-      HOST: "https://aggregator-telco-router-1.opengateway.baikalplatform.es"
-      # HOST: "http://aggregator-telco-router-1:3311" ###
+      HOST: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "aggregator-telco-router-1"
       OPERATOR_ID: "TELEFONICA"
@@ -45,8 +44,7 @@ services:
     environment:
       PORT: 3322
       TELCO_FINDER_HOST: "http://aggregator-telco-finder-2:2222"
-      HOST: "https://aggregator-telco-router-2.opengateway.baikalplatform.es"
-      # HOST: "http://aggregator-telco-router-2:3322" ###
+      HOST: "${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "aggregator-telco-router-2"
       OPERATOR_ID: "VODAFONE"
@@ -116,12 +114,10 @@ services:
     restart: on-failure
     environment:
       PORT: 9010
-      HOST: "https://operator-platform-authserver-1.opengateway.baikalplatform.es"
-      # HOST: "http://operator-platform-authserver-1:9010" ###
+      HOST: "${OPERATOR_PLATFORM_AUTHSERVER_1_HOST:-http://operator-platform-authserver-1:9010}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-telefonica"
-      ADDITIONAL_AUDIENCES: "https://aggregator-telco-router-1.opengateway.baikalplatform.es/,https://aggregator-telco-router-2.opengateway.baikalplatform.es/"
-      # ADDITIONAL_AUDIENCES: "http://aggregator-telco-router-1:3311/,http://aggregator-telco-router-2:3322/" ###
+      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311},${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}"
       OPERATOR_ID: "TELEFONICA"
     ports:
       - 9010:9010
@@ -134,12 +130,10 @@ services:
     restart: on-failure
     environment:
       PORT: 9020
-      HOST: "https://operator-platform-authserver-2.opengateway.baikalplatform.es"
-      # HOST: "http://operator-platform-authserver-2:9020" ###
+      HOST: "${OPERATOR_PLATFORM_AUTHSERVER_2_HOST:-http://operator-platform-authserver-2:9020}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-vodafone"
-      ADDITIONAL_AUDIENCES: "https://aggregator-telco-router-1.opengateway.baikalplatform.es/,https://aggregator-telco-router-2.opengateway.baikalplatform.es/"
-      # ADDITIONAL_AUDIENCES: "http://aggregator-telco-router-1:3311/,http://aggregator-telco-router-2:3322/" ###
+      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311},${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}"
       OPERATOR_ID: "VODAFONE"
     ports:
       - 9020:9020
@@ -170,13 +164,9 @@ services:
     restart: on-failure
     environment:
       PORT: 3000
-      HOST: "https://opengateway.baikalplatform.es"
-      # HOST: "http://localhost:3000" ###
-      # Aggregator configuration
-      CAMARA_API_URL: 'https://aggregator-telco-router-2.opengateway.baikalplatform.es/api'
-      # CAMARA_API_URL: 'http://aggregator-telco-router-2:3322/api'
-      CAMARA_AUTH_URL: 'https://aggregator-telco-router-2.opengateway.baikalplatform.es/oauth2'
-      # CAMARA_AUTH_URL: 'http://aggregator-telco-router-2:3322/oauth2'
+      HOST: "${DEMO_APP_HOST:-http://localhost:3000}"
+      CAMARA_API_URL: "${CAMARA_API_URL:-http://aggregator-telco-router-2:3322/api}"
+      CAMARA_AUTH_URL: "${CAMARA_API_URL:-http://aggregator-telco-router-2:3322/oauth2}"
       CAMARA_ISSUER: '73902489-c201-4819-bdf9-3708a484fe21'
       CAMARA_CLIENT_ID: '73902489-c201-4819-bdf9-3708a484fe21'
       # For JWKS feature

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       HOST: "${OPERATOR_PLATFORM_AUTHSERVER_1_HOST:-http://operator-platform-authserver-1:9010}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-telefonica"
-      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311},${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}"
+      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311}/,${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}/"
       OPERATOR_ID: "TELEFONICA"
     ports:
       - 9010:9010
@@ -133,7 +133,7 @@ services:
       HOST: "${OPERATOR_PLATFORM_AUTHSERVER_2_HOST:-http://operator-platform-authserver-2:9020}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-vodafone"
-      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311},${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}"
+      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311}/,${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}/"
       OPERATOR_ID: "VODAFONE"
     ports:
       - 9020:9020

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       PORT: 3000
       HOST: "${DEMO_APP_HOST:-http://localhost:3000}"
       CAMARA_API_URL: "${CAMARA_API_URL:-http://aggregator-telco-router-2:3322/api}"
-      CAMARA_AUTH_URL: "${CAMARA_API_URL:-http://aggregator-telco-router-2:3322/oauth2}"
+      CAMARA_AUTH_URL: "${CAMARA_AUTH_URL:-http://aggregator-telco-router-2:3322/oauth2}"
       CAMARA_ISSUER: '73902489-c201-4819-bdf9-3708a484fe21'
       CAMARA_CLIENT_ID: '73902489-c201-4819-bdf9-3708a484fe21'
       # For JWKS feature


### PR DESCRIPTION
Set host environment variables in a service's containers with the environment attribute. Default values for localhost environment.
 
The advantage of this method is that you can store the file anywhere and name it appropriately, for example, .env.azure This file path is relative to the current working directory where the Docker Compose command is executed. Passing the file path is done using the --env-file option:

`docker compose --env-file ./.env.azure up --build --remove-orphans`

For security reasons, the --env-file file will only be on the host where it is executed.

