### PR TITLE
chore: assertion rebuilding in aggregator

### DIFF
--- a/aggregator/telco-router/service/src/aggregator/oauth2/telcorouter/grant_types.py
+++ b/aggregator/telco-router/service/src/aggregator/oauth2/telcorouter/grant_types.py
@@ -2,6 +2,7 @@ import logging
 import time
 from base64 import urlsafe_b64encode
 from collections import OrderedDict
+from copy import deepcopy
 from urllib.parse import urlencode, parse_qsl
 
 import oauthlib.oauth2.rfc6749.grant_types.base
@@ -11,7 +12,6 @@ from django.conf import settings
 from django.urls import reverse
 from jwcrypto.jwk import JWK
 from jwcrypto.jws import JWS, InvalidJWSSignature
-from jwcrypto.jwt import JWT
 from oauthlib import common
 from oauthlib.oauth2 import AuthorizationCodeGrant
 from oauthlib.oauth2.rfc6749 import errors
@@ -28,9 +28,9 @@ from aggregator.utils.exceptions import MissingParameterError, InvalidParameterV
 from aggregator.utils.http import do_request_call
 from aggregator.utils.jwe import build_jwe
 from aggregator.utils.jwk import JWKManager
-from aggregator.utils.jws import validate_jws_header, get_jws_info, FIELD_ALGORITHM
+from aggregator.utils.jws import validate_jws_header, get_jws_info, FIELD_ALGORITHM, build_jws
 from aggregator.utils.schemas import FIELD_SUB, FIELD_SCOPE, FIELD_KID, FIELD_JTI, FIELD_ISSUER, FIELD_AUDIENCE, FIELD_ISSUED_TIME, FIELD_EXPIRATION, \
-    FIELD_REDIRECT_URI, FIELD_ROUTING, FIELD_STATE, FIELD_CODE, FIELD_CLIENT_ID
+    FIELD_REDIRECT_URI, FIELD_ROUTING, FIELD_STATE, FIELD_CODE, FIELD_CLIENT_ID, FIELD_CLIENT_ASSERTION, FIELD_ASSERTION
 from aggregator.utils.utils import enrich_object, get_cleaned_data
 
 logger = logging.getLogger(settings.LOGGING_PREFIX)
@@ -237,6 +237,23 @@ class AggregatorAuthorizationCodeGrantMixin:
 
 class AggregatorOAuth2AuthorizationCodeGrant(AggregatorAuthorizationCodeGrantMixin, OAuth2AuthorizationCodeGrant):
 
+    def _get_routing_params(self, request):
+        content_type = request.headers.get('Content-Type', None)
+        if content_type == 'application/json':
+            params = request.body
+        else:
+            params = dict(parse_qsl(request.body))
+
+        params[FIELD_REDIRECT_URI] = settings.AGGREGATOR_HOST + reverse('aggregator-callback')
+        params[FIELD_CODE] = request.auth[FIELD_CODE]
+
+        if hasattr(request, FIELD_CLIENT_ASSERTION):
+            client_assertion = deepcopy(getattr(request, FIELD_CLIENT_ASSERTION))
+            client_assertion.update({FIELD_AUDIENCE: request.routing['authserver_url']})
+            params[FIELD_CLIENT_ASSERTION] = build_jws(client_assertion)
+
+        return params
+
     def _get_routing_token(self, request):
         request.routing = request.auth[FIELD_ROUTING]
 
@@ -245,25 +262,17 @@ class AggregatorOAuth2AuthorizationCodeGrant(AggregatorAuthorizationCodeGrantMix
         headers = {AggregatorMiddleware.AGGREGATOR_CORRELATOR_HEADER: AggregatorMiddleware.get_correlator(AggregatorMiddleware.get_current_request()),
                    'Content-Type': 'application/x-www-form-urlencoded'}
 
-        content_type = request.headers.get('Content-Type', None)
-        if content_type == 'application/json':
-            params = request.body
-        else:
-            params = dict(parse_qsl(request.body))
-        params[FIELD_REDIRECT_URI] = settings.AGGREGATOR_HOST + reverse('aggregator-callback')
-        params[FIELD_CODE] = request.auth[FIELD_CODE]
-
         response = do_request_call('Routing Token', 'POST', metadata['token_endpoint'],
-                                   headers=headers, data=urlencode(params),
+                                   headers=headers, data=urlencode(self._get_routing_params(request)),
                                    verify=settings.API_VERIFY_CERTIFICATE, timeout=settings.API_HTTP_TIMEOUT)
 
         if response.status_code == requests.codes.ok:  # @UndefinedVariable
             return response.json()
         else:
             body = response.json()
-            raise CustomOAuth2Error(body['error'], status_code=response.status_code, description=body['error_description'])
+            raise CustomOAuth2Error(body['error'], status_code=response.status_code, description=body.get('error_description', None))
 
-    def _get_id_token(self, request, id_token):
+    def _build_id_token(self, request, id_token):
         jws_token = JWS()
         jws_token.deserialize(id_token)
         jwks_uri = OidcClient().get_data(request.routing['authserver_url'], 'jwks_uri')
@@ -272,15 +281,12 @@ class AggregatorOAuth2AuthorizationCodeGrant(AggregatorAuthorizationCodeGrantMix
 
         id_token_data = {k: v for (k, v) in id_token_data.items() if not k.endswith('_hash')}
         id_token_data[FIELD_ISSUER] = settings.AGGREGATOR_ISSUER
-
-        jwt = JWT(header={'alg': settings.JWT_SIGNING_ALGORITHM, 'kid': settings.JWT_KID}, claims=id_token_data)
-        jwt.make_signed_token(JWKManager().get_private_key())
-        return jwt.serialize(True)
+        return build_jws(id_token_data)
 
     def _generate_token(self, request, token_handler):
         request.token = self._get_routing_token(request)
         request.refresh_token = None
-        request.extra_credentials = {"id_token": self._get_id_token(request, request.token["id_token"])} if "id_token" in request.token else {}
+        request.extra_credentials = {"id_token": self._build_id_token(request, request.token["id_token"])} if "id_token" in request.token else {}
         if FIELD_SCOPE in request.token:
             request.scopes = request.token[FIELD_SCOPE].split(' ')
         return request.token
@@ -289,7 +295,6 @@ class AggregatorOAuth2AuthorizationCodeGrant(AggregatorAuthorizationCodeGrantMix
         headers = self._get_default_headers()
         try:
             self.validate_token_request(request)
-            logger.debug('Token request validation ok for %r.', request)
         except errors.OAuth2Error as e:
             logger.debug('Client error during validation of %r. %r.', request, e)
             headers.update(e.headers)
@@ -363,6 +368,27 @@ class AggregatorJWTBearerGrant(oauthlib.oauth2.rfc6749.grant_types.base.GrantTyp
         for validator in self.custom_validators.post_token:
             validator(request)
 
+    def _get_routing_params(self, request):
+        content_type = request.headers.get('Content-Type', None)
+        if content_type == 'application/json':
+            params = request.body
+        else:
+            params = dict(parse_qsl(request.body))
+
+        if hasattr(request, FIELD_CLIENT_ASSERTION):
+            client_assertion = deepcopy(getattr(request, FIELD_CLIENT_ASSERTION))
+            client_assertion.update({FIELD_AUDIENCE: request.routing['authserver_url']})
+            params[FIELD_CLIENT_ASSERTION] = build_jws(client_assertion)
+
+        assertion = deepcopy(request.auth)
+        assertion.update({
+            FIELD_ISSUER: settings.AGGREGATOR_ISSUER if assertion[FIELD_ISSUER] != request.client.client_id else assertion[FIELD_ISSUER],
+            FIELD_AUDIENCE: request.routing['authserver_url']
+        })
+        params[FIELD_ASSERTION] = build_jws(assertion)
+
+        return params
+
     def _get_routing_token(self, request):
         index = request.auth[FIELD_SUB].find(":")
         request.routing = TelcoFinderClient().get_routing_metadata(request.auth[FIELD_SUB][0:index], request.auth[FIELD_SUB][index+1:])
@@ -374,13 +400,14 @@ class AggregatorJWTBearerGrant(oauthlib.oauth2.rfc6749.grant_types.base.GrantTyp
         headers = {AggregatorMiddleware.AGGREGATOR_CORRELATOR_HEADER: AggregatorMiddleware.get_correlator(AggregatorMiddleware.get_current_request()),
                    'Content-Type': 'application/x-www-form-urlencoded'}
         response = do_request_call('Routing Token', 'POST', metadata['token_endpoint'],
-                        headers=headers, data=request.body, verify=settings.API_VERIFY_CERTIFICATE, timeout=settings.API_HTTP_TIMEOUT)
+                                   headers=headers, data=urlencode(self._get_routing_params(request)),
+                                   verify=settings.API_VERIFY_CERTIFICATE, timeout=settings.API_HTTP_TIMEOUT)
 
         if response.status_code == requests.codes.ok:  # @UndefinedVariable
             return response.json()
         else:
             body = response.json()
-            raise CustomOAuth2Error(body['error'], status_code=response.status_code, description=body['error_description'])
+            raise CustomOAuth2Error(body['error'], status_code=response.status_code, description=body.get('error_description', None))
 
     def _generate_token(self, request, token_handler):
         request.refresh_token = None

--- a/aggregator/telco-router/service/src/aggregator/oauth2/telcorouter/validators.py
+++ b/aggregator/telco-router/service/src/aggregator/oauth2/telcorouter/validators.py
@@ -112,6 +112,7 @@ class AggregatorRequestValidator(RequestValidator):
                     signature_key = self.get_signature_key(jws_token.jose_header[FIELD_KID], request)
                     jwt = get_jws_info(jws_token, signature_key, request.client_id, settings.AGGREGATOR_AUDIENCES, validator=None)
                     self._validate_client_assertion(jwt.payload, request)
+                    request.client_assertion = jwt.payload
                     return True
             except InvalidJWSSignature:
                 raise InvalidClientError(description=InvalidSignatureError.description, request=request)

--- a/aggregator/telco-router/service/src/aggregator/utils/jwe.py
+++ b/aggregator/telco-router/service/src/aggregator/utils/jwe.py
@@ -22,7 +22,7 @@ FIELD_ALGORITHM = 'alg'
 FIELD_ENCRYPTION = 'enc'
 FIELD_CORRELATOR = 'corr'
 
-JWT = namedtuple('JWT', ['header', 'payload'])
+JWTObject = namedtuple('JWT', ['header', 'payload'])
 
 
 class KeySetStorage(object, metaclass=Singleton):
@@ -73,7 +73,7 @@ def get_jwe_info(jwe_token, audience=None, validator=None):
         if FIELD_EXPIRATION in payload and payload[FIELD_EXPIRATION] + settings.AUTH_REQUEST_JWT_TIME_LEEWAY < now:
             raise JWTException('Expired JWT token')
 
-        return JWT(jwe_token.jose_header, payload)
+        return JWTObject(jwe_token.jose_header, payload)
     except JWTException as e:
         raise
     except InvalidJWEData as e:

--- a/aggregator/telco-router/service/src/aggregator/utils/schemas.py
+++ b/aggregator/telco-router/service/src/aggregator/utils/schemas.py
@@ -31,6 +31,8 @@ FIELD_IDENTIFIER = 'identifier'
 FIELD_ROUTING = 'routing'
 FIELD_STATE = 'state'
 FIELD_CODE = 'code'
+FIELD_ASSERTION = 'assertion'
+FIELD_CLIENT_ASSERTION = 'client_assertion'
 
 FIELD_ALG = 'alg'
 FIELD_KID = 'kid'
@@ -82,7 +84,10 @@ JWT_CLIENT_ASSERTION_PAYLOAD = {
     'type': 'object',
     'properties': {
         FIELD_AUDIENCE: {
-            'type': 'string'
+            "anyOf": [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}}
+            ]
         },
         FIELD_ISSUER: {
             'type': 'string'
@@ -113,7 +118,10 @@ JWT_ASSERTION_PAYLOAD = {
     'type': 'object',
     'properties': {
         FIELD_AUDIENCE: {
-            'type': 'string'
+            "anyOf": [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}}
+            ]
         },
         FIELD_ISSUER: {
             'type': 'string'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,6 @@ services:
       HOST: "${OPERATOR_PLATFORM_AUTHSERVER_1_HOST:-http://operator-platform-authserver-1:9010}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-telefonica"
-      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311}/,${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}/"
       OPERATOR_ID: "TELEFONICA"
     ports:
       - 9010:9010
@@ -133,7 +132,6 @@ services:
       HOST: "${OPERATOR_PLATFORM_AUTHSERVER_2_HOST:-http://operator-platform-authserver-2:9020}"
       DATABASE_HOST: "mongodb:27017"
       DATABASE_NAME: "authserver-vodafone"
-      ADDITIONAL_AUDIENCES: "${AGGREGATOR_TELCO_ROUTER_1_HOST:-http://aggregator-telco-router-1:3311}/,${AGGREGATOR_TELCO_ROUTER_2_HOST:-http://aggregator-telco-router-2:3322}/"
       OPERATOR_ID: "VODAFONE"
     ports:
       - 9020:9020

--- a/mongo-seed/azure/app-provision.js
+++ b/mongo-seed/azure/app-provision.js
@@ -29,7 +29,7 @@ db.apps.replaceOne(
             }
         ],
         sector_identifier_uri : "https://opengateway.baikalplatform.es",
-        jwks_uri : "https://opengateway.baikalplatform.es/api/jwks",
+        jwks_uri : "https://aggregator-telco-router-2.opengateway.baikalplatform.es/oauth2/jwks",
         redirect_uri : [
             "https://aggregator-telco-router-2.opengateway.baikalplatform.es/oauth2/authorize/callback"
         ]

--- a/mongo-seed/localhost/app-provision.js
+++ b/mongo-seed/localhost/app-provision.js
@@ -29,7 +29,7 @@ db.apps.replaceOne(
             }
         ],
         sector_identifier_uri : "http://localhost:3000",
-        jwks_uri : "http://demo-app:3000/api/jwks",
+        jwks_uri : "http://aggregator-telco-router-2:3322/oauth2/jwks",
         redirect_uri : [
             "http://aggregator-telco-router-2:3322/oauth2/authorize/callback"
         ]

--- a/operator-platform/authserver/service/src/authserver/utils/schemas.py
+++ b/operator-platform/authserver/service/src/authserver/utils/schemas.py
@@ -79,7 +79,10 @@ JWT_CLIENT_ASSERTION_PAYLOAD = {
     'type': 'object',
     'properties': {
         FIELD_AUDIENCE: {
-            'type': 'string'
+            "anyOf": [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}}
+            ]
         },
         FIELD_ISSUER: {
             'type': 'string'
@@ -110,7 +113,10 @@ JWT_ASSERTION_PAYLOAD = {
     'type': 'object',
     'properties': {
         FIELD_AUDIENCE: {
-            'type': 'string'
+            "anyOf": [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}}
+            ]
         },
         FIELD_ISSUER: {
             'type': 'string'
@@ -160,7 +166,10 @@ JWT_LOGIN_HINT_TOKEN_PAYLOAD = {
     'type': 'object',
     'properties': {
         FIELD_AUDIENCE: {
-            'type': 'string'
+            "anyOf": [
+                {'type': 'string'},
+                {'type': 'array', 'items': {'type': 'string'}}
+            ]
         },
         FIELD_ISSUER: {
             'type': 'string'


### PR DESCRIPTION
There is no need of multiple audiences if the aggregator rebuild any assertion from apps. In that case, the assertion is rewritten by the aggregator and signed with its private key because the public key provisioned for the app in operator authserver will be the public key of the aggregator.